### PR TITLE
Added functionality to activate element on mobile browsers

### DIFF
--- a/src/spotify-types.ts
+++ b/src/spotify-types.ts
@@ -154,6 +154,7 @@ export interface SpotifyWebPlaybackPlayer {
     (event: SpotifyWebPlaybackStatusType, callback: SpotifyStatusCallback): boolean;
   };
   connect: SpotifyWebPlaybackMethod<void, boolean>;
+  activateElement: SpotifyWebPlaybackMethod<void, Promise<void>>;
   disconnect: SpotifyWebPlaybackMethod;
   getCurrentState: SpotifyWebPlaybackMethod<void, Promise<SpotifyWebPlaybackState | null>>;
   getVolume: SpotifyWebPlaybackMethod<void, number>;

--- a/src/spotify.ts
+++ b/src/spotify.ts
@@ -150,6 +150,27 @@ export class SpotifyPlayer {
   }
 
   /**
+   * Wait for the element to be activated for mobile devices
+   *
+   * @returns Promise that resolves to a boolean indicating if the activation
+   * was successful.
+   */
+
+  activateElement() {
+    if (!this._player) {
+      return Promise.resolve(false)
+    }
+    const player = this._player
+    return new Promise( resolve => {
+      player.activateElement().then(() => {
+        resolve(true)
+      }).catch(() => {
+        resolve(false)
+      })
+    })
+  }
+
+  /**
    * Wait for the player to connect and emit the 'ready' signal.
    *
    * @returns Promise that resolves to a boolean indicating if the connection


### PR DESCRIPTION
I wrote a function to be able to call the built in function "activateElement" on the spotifyPlayer. This is needed for playback on mobile devices.